### PR TITLE
translate: support stdout redirections

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -78,7 +78,7 @@ func (t *Translator) stmt(s *syntax.Stmt) {
 			t.str(r.N.Value)
 		}
 		switch r.Op {
-		case syntax.RdrInOut, syntax.RdrIn, syntax.AppOut, syntax.DplIn, syntax.DplOut:
+		case syntax.RdrInOut, syntax.RdrIn, syntax.RdrOut, syntax.AppOut, syntax.DplIn, syntax.DplOut:
 			t.str(r.Op.String())
 			t.word(r.Word, false)
 		case syntax.Hdoc:


### PR DESCRIPTION
Otherwise:

    $  echo 'echo > /dev/null' | babelfish

errors out.

---

Closes https://github.com/bouk/babelfish/issues/6.