### PR TITLE
Deal with Bash `unset`'s `-v` and `-f` flag.

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -451,12 +451,24 @@ func (t *Translator) callExpr(c *syntax.CallExpr) {
 		case "shift":
 			t.str("set -e argv[1]")
 		case "unset":
-			t.str("set -e ")
-			for i, a := range c.Args[1:] {
-				if i > 0 {
-					t.str("; set -e ")
+			firstArg, _ := lit(c.Args[1])
+			if firstArg == "-f" {
+				// this unset is 'unsetting' functions (not variables)
+				t.str("functions -e ")
+				for i, a := range c.Args[2:] {
+					if i > 0 {
+						t.str("; functions -e ")
+					}
+					t.word(a, false)
 				}
-				t.word(a, false)
+			} else {
+				t.str("set -e ")
+				for i, a := range c.Args[1:] {
+					if i > 0 {
+						t.str("; set -e ")
+					}
+					t.word(a, false)
+				}
 			}
 			return
 		case "hash":

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -451,24 +451,27 @@ func (t *Translator) callExpr(c *syntax.CallExpr) {
 		case "shift":
 			t.str("set -e argv[1]")
 		case "unset":
-			firstArg, _ := lit(c.Args[1])
-			if firstArg == "-f" {
-				// this unset is 'unsetting' functions (not variables)
-				t.str("functions -e ")
-				for i, a := range c.Args[2:] {
-					if i > 0 {
-						t.str("; functions -e ")
-					}
-					t.word(a, false)
+			isFirst := true
+			unsetFunc := false
+			for _, a := range c.Args[1:] {
+				aStr, _ := lit(a)
+				if aStr == "-f" {
+					unsetFunc = true
+					continue
+				} else if aStr == "-v" {
+					unsetFunc = false
+					continue
 				}
-			} else {
-				t.str("set -e ")
-				for i, a := range c.Args[1:] {
-					if i > 0 {
-						t.str("; set -e ")
-					}
-					t.word(a, false)
+				if !isFirst {
+					t.str("; ")
 				}
+				isFirst = false
+				if unsetFunc {
+					t.str("functions -e ")
+				} else {
+					t.str("set -e ")
+				}
+				t.word(a, false)
 			}
 			return
 		case "hash":

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -66,6 +66,12 @@ export NIX_PATH="$HOME/.nix-defexpr/channels${NIX_PATH:+:$NIX_PATH}"`,
 set -gx NIX_PATH "$HOME"'/.nix-defexpr/channels'(test -n "$NIX_PATH" && echo ':'"$NIX_PATH" || echo)
 `,
 		},
+		{
+			name: "unset function and variable",
+			in:   "unset -f foo -v bar",
+			expected: `functions -e foo; set -e bar
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Unset in bash is able to alternate between unsetting functions and variables, using the `-f` and `-v` flags, respectively.

This fixes a problem where babelfish would translate `unset -f foo` to `set -e -f; set -e foo`. The correct translation would be `functions -e foo`.