### PR TITLE
fix compile: no required module provides package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module bou.ke/babelfish
+module github.com/bouk/babelfish
 
 go 1.14
 
 require (
+	bou.ke/babelfish v1.1.0
 	github.com/google/go-cmp v0.5.4
 	mvdan.cc/sh/v3 v3.1.1-0.20200611202847-1a815c3846d1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/babelfish v1.1.0 h1:tbm1ILNkK9Un4+CE/ge9vdVHoxbJGWiM3LWZh64XJB8=
+bou.ke/babelfish v1.1.0/go.mod h1:3lWBLbWGUmILo8PvxWUS3qc/0v0zYyy52EJW4p+A+Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=


### PR DESCRIPTION
fix build on voidlinux with patch.
https://github.com/void-linux/void-packages/pull/44023/checks

fix: #21
