### PR TITLE
Update Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Because I got annoyed by having to use [fish-foreign-env](https://github.com/oh-
 
 ## Install
 
-`GO111MODULE=on go get bou.ke/babelfish`
+`GO111MODULE=on go install bou.ke/babelfish@latest`
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Because I got annoyed by having to use [fish-foreign-env](https://github.com/oh-
 
 ## Install
 
-`GO111MODULE=on go install bou.ke/babelfish@latest`
+`go install bou.ke/babelfish@latest`
 
 ## Example
 


### PR DESCRIPTION
As of Go 1.18,
> `go get`'s ability to build and install commands is now [deprecated](https://go.dev/doc/go-get-install-deprecation).

Raising the following with the current install method,
>`... 'go get' is no longer supported outside a module. To build and install a command, use 'go install' with a version, ...`

PR fixes and closes issue [#17](https://github.com/bouk/babelfish/issues/17).