### PR TITLE
Replace manual trimming with `strings.TrimPrefix`

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -709,9 +709,7 @@ func (t *Translator) paramExp(p *syntax.ParamExp, quoted bool) {
 			if err != nil {
 				unsupported(p)
 			}
-      if strings.HasPrefix(expr, "(?s)") {
-        expr = expr[4:]
-      }
+			expr = strings.TrimPrefix(expr, "(?s)")
 			dot := ""
 			if isPath && (suffix && strings.HasSuffix(expr, ":") || !suffix && strings.HasPrefix(expr, ":")) {
 				dot = `\.?`


### PR DESCRIPTION
Hey, just wanted to say thx for this amazing project! 💙

This PR replaces the manual `expr` trimming.

Instead of using `strings.HasPrefix`, it seems a good idea to grab `strings.TrimPrefix`.

See [S1017 - Replace manual trimming with strings.TrimPrefix](https://staticcheck.dev/docs/checks#S1017)

The `gotestsum` tests seem to be passing, but I'd like your feedback to avoid introducing any change of behavior.

Cheers!