### PR TITLE
Update `go` version to `1.23` in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module bou.ke/babelfish
 
-go 1.19
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
`1.19` was few years ago, and `babelfish` seems to compile fine under `1.23`

For release notes see: [Release History - The Go Programming Language](https://go.dev/doc/devel/release)