### PR TITLE
Add initial `set` support

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -431,13 +431,11 @@ func (t *Translator) parseSetExpr(args []*syntax.Word) bool {
 
 	next, _ := lit(args[1])
 
-	if next == "--" {
-		if len(args) > 2 {
-			t.str("set argv")
-			for _, arg := range args[2:] {
-				t.str(" ")
-				t.word(arg, false)
-			}
+	if (next == "--" || next == "-") {
+		t.str("set argv")
+		for _, arg := range args[2:] {
+			t.str(" ")
+			t.word(arg, false)
 		}
 		return true
 	}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -424,10 +424,24 @@ func (t *Translator) assign(prefix string, a *syntax.Assign) {
 	}
 }
 
-func (t *Translator) parseSetExp(args []*syntax.Word) bool {
+func (t *Translator) parseSetExpr(args []*syntax.Word) bool {
 	if len(args) < 2 {
 		return false
 	}
+
+	next, _ := lit(args[1])
+
+	if next == "--" {
+		if len(args) > 2 {
+			t.str("set argv")
+			for _, arg := range args[2:] {
+				t.str(" ")
+				t.word(arg, false)
+			}
+		}
+		return true
+	}
+
 	for _, arg := range args[1:] {
 		flag, _ := lit(arg)
 		if !strings.HasPrefix(flag, "-") {
@@ -463,7 +477,7 @@ func (t *Translator) callExpr(c *syntax.CallExpr) {
 
 		switch l {
 		case "set":
-			if t.parseSetExp(c.Args) {
+			if t.parseSetExpr(c.Args) {
 				return
 			}
 		case "shift":

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -424,6 +424,19 @@ func (t *Translator) assign(prefix string, a *syntax.Assign) {
 	}
 }
 
+func (t *Translator) parseSetExp(args []*syntax.Word) bool {
+	if len(args) < 2 {
+		return false
+	}
+	for _, arg := range args[1:] {
+		flag, _ := lit(arg)
+		if !strings.HasPrefix(flag, "-") {
+			return false
+		}
+	}
+	return true
+}
+
 func (t *Translator) callExpr(c *syntax.CallExpr) {
 	if len(c.Args) == 0 {
 		// assignment
@@ -447,7 +460,12 @@ func (t *Translator) callExpr(c *syntax.CallExpr) {
 
 		first := c.Args[0]
 		l, _ := lit(first)
+
 		switch l {
+		case "set":
+			if t.parseSetExp(c.Args) {
+				return
+			}
 		case "shift":
 			t.str("set -e argv[1]")
 		case "unset":

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -448,7 +448,18 @@ func (t *Translator) parseSetExpr(args []*syntax.Word) bool {
 
 	next, _ := lit(args[1])
 
-	if (next == "--" || next == "-") {
+	if next == "--" || next == "-" {
+		if len(args) >= 3 && isAtWord(args[len(args)-1]) {
+			if len(args) > 3 {
+				t.str("set -a argv")
+				for _, arg := range args[2 : len(args)-1] {
+					t.str(" ")
+					t.word(arg, false)
+				}
+			}
+			return true
+		}
+
 		t.str("set argv")
 		for _, arg := range args[2:] {
 			t.str(" ")
@@ -464,6 +475,21 @@ func (t *Translator) parseSetExpr(args []*syntax.Word) bool {
 		}
 	}
 	return true
+}
+
+func isAtWord(w *syntax.Word) bool {
+	if len(w.Parts) != 1 {
+		return false
+	}
+	dq, ok := w.Parts[0].(*syntax.DblQuoted)
+	if !ok || len(dq.Parts) != 1 {
+		return false
+	}
+	param, ok := dq.Parts[0].(*syntax.ParamExp)
+	if !ok {
+		return false
+	}
+	return param.Param.Value == "@"
 }
 
 func (t *Translator) callExpr(c *syntax.CallExpr) {

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -333,6 +333,8 @@ echo ${cool+a}
 echo ${cool:+a}
 echo ${cool-a}
 echo ${cool:-a}
+set -Cefu
+set -- x y z
 unset ASPELL_CONF
 for i in a b c ; do
   if [ -d "$i/lib/aspell" ]; then
@@ -392,6 +394,8 @@ echo (set -q cool && echo 'a' || echo)
 echo (test -n "$cool" && echo 'a' || echo)
 echo (set -q cool && echo "$cool" || echo 'a')
 echo (test -n "$cool" && echo "$cool" || echo 'a')
+
+set argv x y z
 set -e ASPELL_CONF
 for i in a b c
   if [ -d "$i"'/lib/aspell' ]

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -335,6 +335,7 @@ echo ${cool-a}
 echo ${cool:-a}
 set -Cefu
 set -- x y z
+set - x y z
 unset ASPELL_CONF
 for i in a b c ; do
   if [ -d "$i/lib/aspell" ]; then
@@ -395,6 +396,7 @@ echo (test -n "$cool" && echo 'a' || echo)
 echo (set -q cool && echo "$cool" || echo 'a')
 echo (test -n "$cool" && echo "$cool" || echo 'a')
 
+set argv x y z
 set argv x y z
 set -e ASPELL_CONF
 for i in a b c

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -338,6 +338,7 @@ echo ${cool:-a}
 set -Cefu
 set -- x y z
 set - x y z
+set -- x "$@"
 unset ASPELL_CONF
 for i in a b c; do
   if [ -d "$i/lib/aspell" ]; then
@@ -404,6 +405,7 @@ echo (test -n "$cool" && echo "$cool" || echo 'a')
 
 set argv x y z
 set argv x y z
+set -a argv x
 set -e ASPELL_CONF
 for i in a b c
   if [ -d "$i"'/lib/aspell' ]


### PR DESCRIPTION
Fixes #34 #35 

Would love some guidance to create the tests.

###### Note: Currently doesn't support `set -- x y "$@"` to append. This is equivalent to `fish`'s `set -a argv x y`