### PR TITLE
Fix `for` loop extra whitespace in `translate_test.go`

### DIFF
--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -334,7 +334,7 @@ echo ${cool:+a}
 echo ${cool-a}
 echo ${cool:-a}
 unset ASPELL_CONF
-for i in a b c ; do
+for i in a b c; do
   if [ -d "$i/lib/aspell" ]; then
     export ASPELL_CONF="dict-dir $i/lib/aspell"
   fi


### PR DESCRIPTION
Very minute typo, noticed the ` ; do` instead of `; do`, to be even with the rest of the statements.