### PR TITLE
translate: support combined stream redirection and append

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -90,7 +90,7 @@ func (t *Translator) stmt(s *syntax.Stmt) {
 			t.str(r.N.Value)
 		}
 		switch r.Op {
-		case syntax.RdrInOut, syntax.RdrIn, syntax.RdrOut, syntax.AppOut, syntax.DplIn, syntax.DplOut:
+		case syntax.RdrInOut, syntax.RdrIn, syntax.RdrOut, syntax.RdrAll, syntax.AppOut, syntax.AppAll, syntax.DplIn, syntax.DplOut:
 			t.str(r.Op.String())
 			t.word(r.Word, false)
 		case syntax.Hdoc:

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -79,6 +79,60 @@ nix run $a#hello
 nix run $a#hello
 `,
 		},
+		{
+			name: "stderr follows stdout redirect",
+			in:   `echo 123 > /dev/null 2>&1`,
+			expected: `echo 123 >/dev/null 2>&1
+`,
+		},
+		{
+			name: "combined output redirect",
+			in:   `echo 123 &> /dev/null`,
+			expected: `echo 123 &>/dev/null
+`,
+		},
+		{
+			name: "combined output append",
+			in:   `echo 123 &>> /tmp/log`,
+			expected: `echo 123 &>>/tmp/log
+`,
+		},
+		{
+			name: "redirect after stderr to stdout",
+			in:   `echo 123 2>&1 > /dev/null`,
+			expected: `echo 123 2>&1 >/dev/null
+`,
+		},
+		{
+			name: "stderr follows stdout append",
+			in:   `echo 123 >> /dev/null 2>&1`,
+			expected: `echo 123 >>/dev/null 2>&1
+`,
+		},
+		{
+			name: "stderr only",
+			in:   `echo 123 2> /dev/null`,
+			expected: `echo 123 2>/dev/null
+`,
+		},
+		{
+			name: "stderr only append",
+			in:   `echo 123 2>> /dev/null`,
+			expected: `echo 123 2>>/dev/null
+`,
+		},
+		{
+			name: "separate output files",
+			in:   `echo 123 > /dev/null 2> /dev/stderr`,
+			expected: `echo 123 >/dev/null 2>/dev/stderr
+`,
+		},
+		{
+			name: "separate output files append",
+			in:   `echo 123 >> /dev/null 2>> /dev/stderr`,
+			expected: `echo 123 >>/dev/null 2>>/dev/stderr
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
There are probably some obscure syntax not compatible that I've yet to know, but it seems like the below cases are supported in fish:

```sh
echo 123 > /dev/null 2>&1
echo 123 &> /dev/null
echo 123 &>> /tmp/null
echo 123 2>&1 > /dev/null
echo 123 >> /dev/null 2>&1
echo 123 2> /dev/null
echo 123 2>> /dev/null
echo 123 > /dev/null 2> /dev/stderr
echo 123 >> /dev/null 2>> /dev/stderr